### PR TITLE
Update to 1.19.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,14 @@
 plugins {
     java
-    id("fabric-loom") version "0.12.+"
+    id("fabric-loom") version "1.0-SNAPSHOT"
     id("io.github.juuxel.loom-quiltflower") version "1.7.3"
     id("com.github.ben-manes.versions") version "0.42.0"
     id("de.jjohannes.missing-metadata-guava") version "31.1.1"
 }
 
-val minecraftVersion = "1.19.1"
-val fabricLoaderVersion = "0.14.8"
-val fabricApiVersion = "0.58.5+1.19.1"
+val minecraftVersion = "1.19.2"
+val fabricLoaderVersion = "0.14.9"
+val fabricApiVersion = "0.62.0+1.19.2"
 val modmenuVersion = "4.0.5"
 val multiconnectVersion = "1.5.10"
 
@@ -58,7 +58,7 @@ dependencies {
         officialMojangMappings {
             nameSyntheticMembers = false
         }
-        parchment("org.parchmentmc.data:parchment-1.18.2:2022.07.03@zip")
+        parchment("org.parchmentmc.data:parchment-1.19.2:2022.09.18@zip")
     })
     modImplementation("net.fabricmc:fabric-loader:$fabricLoaderVersion")
     modImplementation("com.terraformersmc:modmenu:$modmenuVersion")
@@ -115,7 +115,7 @@ dependencies {
     }
 
     // for development
-    modRuntimeOnly("com.sk89q.worldedit:worldedit-fabric-mc1.19.1:7.2.11-SNAPSHOT") {
+    modRuntimeOnly("com.sk89q.worldedit:worldedit-fabric-mc1.19.2:7.2.12") {
         exclude("com.google.guava", "guava")
         exclude("com.google.code.gson", "gson")
         exclude("com.google.code.gson", "gson")

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -37,7 +37,7 @@
     "fabric-lifecycle-events-v1": "^2.0.0",
     "fabric-screen-api-v1": ">=1.0.9",
     "fabric-resource-loader-v0": ">=0.4.17",
-    "minecraft": ">=1.18.2"
+    "minecraft": ">=1.19.1"
   },
   "suggests": {
     "worldedit": ">=7.2.0"


### PR DESCRIPTION
Performs 1.19.2 update, to resolve a method name change crash. Also updates the version of parchment used to one that supports 1.19.x, and bumps the required MC version to >=1.19.1, as it was >=1.18.2 prior. While this _runs_ on 1.19.1, it will have the same issue that 1.19.2 had prior to this change.

Resolves https://github.com/EngineHub/WorldEditCUI/issues/70