### PR TITLE
Fixed CuboidGrid and CuboidBox being inverted

### DIFF
--- a/src/main/java/org/enginehub/worldeditcui/config/CUIConfiguration.java
+++ b/src/main/java/org/enginehub/worldeditcui/config/CUIConfiguration.java
@@ -74,8 +74,8 @@ public final class CUIConfiguration implements InitialisationFactory
 	private boolean promiscuous = false;
 	private boolean clearAllOnKey = false;
 
-    private Colour cuboidGridColor = ConfiguredColour.CUBOIDBOX.getDefault();
-    private Colour cuboidEdgeColor = ConfiguredColour.CUBOIDGRID.getDefault();
+	private Colour cuboidGridColor = ConfiguredColour.CUBOIDGRID.getDefault();
+	private Colour cuboidEdgeColor = ConfiguredColour.CUBOIDBOX.getDefault();
     private Colour cuboidFirstPointColor = ConfiguredColour.CUBOIDPOINT1.getDefault();
     private Colour cuboidSecondPointColor = ConfiguredColour.CUBOIDPOINT2.getDefault();
     private Colour polyGridColor = ConfiguredColour.POLYGRID.getDefault();
@@ -243,8 +243,8 @@ public final class CUIConfiguration implements InitialisationFactory
 			case "promiscuous":
 			case "clearAllOnKey": return false;
 
-			case "cuboidGridColor": return ConfiguredColour.CUBOIDBOX.getDefault();
-			case "cuboidEdgeColor": return ConfiguredColour.CUBOIDGRID.getDefault();
+			case "cuboidGridColor": return ConfiguredColour.CUBOIDGRID.getDefault();
+			case "cuboidEdgeColor": return ConfiguredColour.CUBOIDBOX.getDefault();
 			case "cuboidFirstPointColor": return ConfiguredColour.CUBOIDPOINT1.getDefault();
 			case "cuboidSecondPointColor": return ConfiguredColour.CUBOIDPOINT2.getDefault();
 			case "polyGridColor": return ConfiguredColour.POLYGRID.getDefault();

--- a/src/main/java/org/enginehub/worldeditcui/config/CUIConfiguration.java
+++ b/src/main/java/org/enginehub/worldeditcui/config/CUIConfiguration.java
@@ -74,8 +74,8 @@ public final class CUIConfiguration implements InitialisationFactory
 	private boolean promiscuous = false;
 	private boolean clearAllOnKey = false;
 
-	private Colour cuboidGridColor = ConfiguredColour.CUBOIDGRID.getDefault();
-	private Colour cuboidEdgeColor = ConfiguredColour.CUBOIDBOX.getDefault();
+    private Colour cuboidGridColor = ConfiguredColour.CUBOIDGRID.getDefault();
+    private Colour cuboidEdgeColor = ConfiguredColour.CUBOIDBOX.getDefault();
     private Colour cuboidFirstPointColor = ConfiguredColour.CUBOIDPOINT1.getDefault();
     private Colour cuboidSecondPointColor = ConfiguredColour.CUBOIDPOINT2.getDefault();
     private Colour polyGridColor = ConfiguredColour.POLYGRID.getDefault();

--- a/src/main/java/org/enginehub/worldeditcui/render/ConfiguredColour.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/ConfiguredColour.java
@@ -18,8 +18,8 @@ import org.enginehub.worldeditcui.render.RenderStyle.RenderType;
  */
 public enum ConfiguredColour
 {
-	CUBOIDBOX      ("cuboidedge",     Colour.parseRgba("#CC3333CC")),
 	CUBOIDGRID     ("cuboidgrid",     Colour.parseRgba("#CC4C4CCC")),
+	CUBOIDBOX      ("cuboidedge",     Colour.parseRgba("#CC3333CC")),
 	CUBOIDPOINT1   ("cuboidpoint1",   Colour.parseRgba("#33CC33CC")),
 	CUBOIDPOINT2   ("cuboidpoint2",   Colour.parseRgba("#3333CCCC")),
 	POLYGRID       ("polygrid",       Colour.parseRgba("#CC3333CC")),


### PR DESCRIPTION
Fixes https://github.com/EngineHub/WorldEditCUI/issues/69

These config values are mapped to an enum by index, but the ordering did not actually match the enum - causing these two values to be read backwards. This fixes up the ordering, and also the default values that appeared to have been flipped