### PR TITLE
Set up automatic publishing from within Gradle

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+    `java-gradle-plugin`
+}
+
+val targetVersion = 11
+java {
+    sourceCompatibility = JavaVersion.toVersion(targetVersion)
+    targetCompatibility = sourceCompatibility
+    if (JavaVersion.current() < JavaVersion.toVersion(targetVersion)) {
+        toolchain.languageVersion = JavaLanguageVersion.of(targetVersion)
+    }
+}
+
+tasks.withType(JavaCompile::class).configureEach {
+    options.release = targetVersion
+    options.encoding = "UTF-8"
+    options.compilerArgs.addAll(listOf("-Xlint:all", "-Xlint:-processing"))
+}
+
+dependencies {
+    implementation(libs.githubApi)
+    implementation(libs.indra.git)
+}
+
+gradlePlugin {
+    plugins {
+        register("publish-gh-release") {
+            id = "org.enginehub.worldeditcui.ghrelease"
+            description = "Publish a GitHub release"
+            implementationClass = "org.enginehub.build.worldeditcui.GitHubReleaserPlugin"
+        }
+    }
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,5 +1,3 @@
-rootProject.name = "WorldEditCUI"
-
 pluginManagement {
     repositories {
         // mirrors:
@@ -19,6 +17,14 @@ pluginManagement {
     }
 }
 
-includeBuild("build-logic") {
-    name = "worldeditcui-build-logic"
+rootProject.name = "worldeditcui-build-logic"
+
+dependencyResolutionManagement {
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+    pluginManagement.repositories.forEach(repositories::add)
+    versionCatalogs {
+        register(defaultLibrariesExtensionName.get()) {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
 }

--- a/build-logic/src/main/java/org/enginehub/build/worldeditcui/GitHubReleaserExtensionImpl.java
+++ b/build-logic/src/main/java/org/enginehub/build/worldeditcui/GitHubReleaserExtensionImpl.java
@@ -1,0 +1,109 @@
+package org.enginehub.build.worldeditcui;
+
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.ProviderFactory;
+
+import javax.inject.Inject;
+
+class GitHubReleaserExtensionImpl implements GithubReleaserExtension {
+    private final Property<String> enterpriseUrl;
+    private final Property<String> apiToken;
+    private final Property<String> releaseTitle;
+    private final Property<String> releaseBody;
+    private final Property<String> repository;
+    private final Property<String> tagName;
+    private final Property<String> sourceBranch;
+    private final Property<Boolean> draft;
+    private final Property<Boolean> prerelease;
+    private final Property<String> discussionCategoryName;
+    private final Property<Boolean> generateReleaseNotes;
+    private final Property<LatestState> makeLatest;
+
+    private final ConfigurableFileCollection sourceArtifacts;
+
+    @Inject
+    public GitHubReleaserExtensionImpl(final ObjectFactory objects, final ProviderFactory providers) {
+        this.enterpriseUrl = objects.property(String.class);
+        this.apiToken = objects.property(String.class)
+                .convention(providers.environmentVariable("GITHUB_TOKEN"));
+        this.releaseTitle = objects.property(String.class);
+        this.releaseBody = objects.property(String.class).convention("");
+        this.repository = objects.property(String.class);
+        this.tagName = objects.property(String.class);
+        this.sourceBranch = objects.property(String.class);
+        this.draft = objects.property(Boolean.class).convention(false);
+        this.prerelease = objects.property(Boolean.class).convention(false);
+        this.discussionCategoryName = objects.property(String.class);
+        this.generateReleaseNotes = objects.property(Boolean.class).convention(false);
+        this.makeLatest = objects.property(LatestState.class).convention(LatestState.TRUE);
+
+        this.sourceArtifacts = objects.fileCollection();
+    }
+
+    @Override
+    public Property<String> getEnterpriseUrl() {
+        return this.enterpriseUrl;
+    }
+
+    @Override
+    public Property<String> getApiToken() {
+        return this.apiToken;
+    }
+
+    @Override
+    public Property<String> getReleaseName() {
+        return this.releaseTitle;
+    }
+
+    @Override
+    public Property<String> getReleaseBody() {
+        return this.releaseBody;
+    }
+
+    @Override
+    public Property<String> getRepository() {
+        return this.repository;
+    }
+
+    @Override
+    public Property<String> getTagName() {
+        return this.tagName;
+    }
+
+    @Override
+    public Property<String> getSourceBranch() {
+        return this.sourceBranch;
+    }
+
+    @Override
+    public Property<Boolean> getDraft() {
+        return this.draft;
+    }
+
+    @Override
+    public Property<Boolean> getPrerelease() {
+        return this.prerelease;
+    }
+
+    @Override
+    public Property<String> getDiscussionCategoryName() {
+        return this.discussionCategoryName;
+    }
+
+    @Override
+    public Property<Boolean> getGenerateReleaseNotes() {
+        return this.generateReleaseNotes;
+    }
+
+    @Override
+    public Property<LatestState> getMakeLatest() {
+        return this.makeLatest;
+    }
+
+    @Override
+    public ConfigurableFileCollection getArtifacts() {
+        return this.sourceArtifacts;
+    }
+}

--- a/build-logic/src/main/java/org/enginehub/build/worldeditcui/GitHubReleaserPlugin.java
+++ b/build-logic/src/main/java/org/enginehub/build/worldeditcui/GitHubReleaserPlugin.java
@@ -1,0 +1,58 @@
+package org.enginehub.build.worldeditcui;
+
+import net.kyori.indra.git.IndraGitExtension;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskContainer;
+
+public class GitHubReleaserPlugin implements Plugin<Project> {
+    public static final String GITHUB_RELEASE_EXTENSION_NAME = "githubRelease";
+    public static final String GITHUB_RELEASE_TASK_NAME = "publishToGitHub";
+
+    @Override
+    public void apply(final Project target) {
+        target.getPlugins().apply("net.kyori.indra.git"); // for git operations
+
+        // extension
+        final GithubReleaserExtension extension = target.getExtensions().create(
+            GithubReleaserExtension.class,
+            GITHUB_RELEASE_EXTENSION_NAME,
+            GitHubReleaserExtensionImpl.class
+        );
+
+        this.configureTasks(target.getTasks(), extension);
+        this.registerPublishTask(target.getTasks(), extension);
+
+        extension.getTagName().convention(target.provider(() -> {
+            final Ref headTag = target.getExtensions().getByType(IndraGitExtension.class).headTag();
+            return headTag == null ? null : Repository.shortenRefName(headTag.getName());
+        }));
+    }
+
+    private void configureTasks(final TaskContainer tasks, final GithubReleaserExtension extension) {
+        tasks.withType(PublishGitHubRelease.class).configureEach(task -> {
+            task.getEnterpriseUrl().set(extension.getEnterpriseUrl());
+            task.getApiToken().set(extension.getApiToken());
+        });
+    }
+
+    private void registerPublishTask(final TaskContainer tasks, final ReleaseJobParameters sourceParameters) {
+        tasks.register(GITHUB_RELEASE_TASK_NAME, PublishGitHubRelease.class, task -> {
+            task.dependsOn("requireClean"); // via indra-git
+
+            task.getReleaseName().set(sourceParameters.getReleaseName());
+            task.getReleaseBody().set(sourceParameters.getReleaseBody());
+            task.getRepository().set(sourceParameters.getRepository());
+            task.getTagName().set(sourceParameters.getTagName());
+            task.getSourceBranch().set(sourceParameters.getSourceBranch());
+            task.getDraft().set(sourceParameters.getDraft());
+            task.getPrerelease().set(sourceParameters.getPrerelease());
+            task.getDiscussionCategoryName().set(sourceParameters.getDiscussionCategoryName());
+            task.getGenerateReleaseNotes().set(sourceParameters.getGenerateReleaseNotes());
+            task.getMakeLatest().set(sourceParameters.getMakeLatest());
+            task.getArtifacts().from(sourceParameters.getArtifacts());
+        });
+    }
+}

--- a/build-logic/src/main/java/org/enginehub/build/worldeditcui/GithubReleaserExtension.java
+++ b/build-logic/src/main/java/org/enginehub/build/worldeditcui/GithubReleaserExtension.java
@@ -1,0 +1,23 @@
+package org.enginehub.build.worldeditcui;
+
+import org.gradle.api.provider.Property;
+
+public interface GithubReleaserExtension extends ReleaseJobParameters {
+    /**
+     * Get an endpoint override for GitHub.
+     *
+     * <p>Only required if using GitHub enterprise.</p>
+     *
+     * @return the base url for the GitHub instance
+     */
+    Property<String> getEnterpriseUrl();
+
+    /**
+     * Get the API token used to authenticate with GitHub.
+     *
+     * <p>By default, this is read from the {@code GITHUB_TOKEN} environment variable.</p>
+     *
+     * @return the api token property
+     */
+    Property<String> getApiToken();
+}

--- a/build-logic/src/main/java/org/enginehub/build/worldeditcui/PublishGitHubRelease.java
+++ b/build-logic/src/main/java/org/enginehub/build/worldeditcui/PublishGitHubRelease.java
@@ -1,0 +1,123 @@
+package org.enginehub.build.worldeditcui;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.TaskAction;
+import org.jetbrains.annotations.NotNull;
+import org.kohsuke.github.GHRelease;
+import org.kohsuke.github.GHReleaseBuilder;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
+import org.kohsuke.github.GitHubRateLimitHandler;
+import org.kohsuke.github.connector.GitHubConnectorResponse;
+
+import java.io.File;
+import java.io.IOException;
+
+public abstract class PublishGitHubRelease extends DefaultTask implements ReleaseJobParameters {
+
+    @Input
+    @Optional
+    public abstract Property<String> getEnterpriseUrl();
+
+    @Input
+    public abstract Property<String> getApiToken();
+
+    private GitHub createGitHub() {
+        final GitHubBuilder builder = new GitHubBuilder();
+        if (this.getEnterpriseUrl().isPresent()) {
+            builder.withEndpoint(this.getEnterpriseUrl().get());
+        }
+        builder.withOAuthToken(this.getApiToken().get());
+        builder.withRateLimitHandler(new GitHubRateLimitHandler() {
+            @Override
+            public void onError(@NotNull GitHubConnectorResponse response) throws IOException {
+                getLogger().error(
+                        "Exceeded rate limit while trying to publish release (code {}): {}",
+                        response.statusCode(),
+                        new String(response.bodyStream().readAllBytes())
+                );
+                throw new GradleException("Rate limmit exceeded! See log for details");
+            }
+        });
+
+        try {
+            return builder.build();
+        } catch (IOException e) {
+            this.getLogger().error("Failed to create GitHub instance: {}", e.getMessage(), e);
+            throw new GradleException("GitHub authentication failed, see log for details");
+        }
+    }
+
+    @TaskAction
+    public void doPublish() {
+        final GitHub gh = this.createGitHub();
+
+        final GHRepository repo = runHandlingException(() -> gh.getRepository(this.getRepository().get()));
+        final GHReleaseBuilder releaseBuilder = repo.createRelease(this.getTagName().get());
+
+        if (this.getReleaseName().isPresent()) {
+            releaseBuilder.name(this.getReleaseName().get());
+        }
+
+        releaseBuilder
+                .body(this.getReleaseBody().getOrElse(""))
+                .draft(true)
+                .prerelease(this.getPrerelease().get());
+
+        if (this.getDiscussionCategoryName().isPresent()) {
+            releaseBuilder.categoryName(this.getDiscussionCategoryName().get());
+        }
+
+        if (this.getSourceBranch().isPresent()) {
+            releaseBuilder.commitish(this.getSourceBranch().get());
+        }
+
+        // todo: generateReleaseNotes
+        // todo: makeLatest
+
+        // update release content
+        final GHRelease release = runHandlingException(releaseBuilder::create);
+        for (final File file : this.getArtifacts()) {
+            if (!file.isFile()) {
+                throw new InvalidUserDataException("Release artifact " + file.getAbsolutePath() + " is not a regular file!");
+            }
+            runHandlingException(() -> release.uploadAsset(file, determineMimeType(file)));
+        }
+
+        // Now that all elements have been done successfully, if we are non-draft then mark it as non-draft
+        if (!this.getDraft().get()) {
+            runHandlingException(release.update().draft(false)::update);
+        }
+    }
+
+    private String determineMimeType(final File file) {
+        final String name = file.getName();
+        if (name.endsWith("jar")) {
+            return "application/java-archive";
+        } else if (name.endsWith("zip")) {
+            return "application/zip";
+        } else { // unknown // todo: find a better way to determine this
+            return "application/octet-stream";
+        }
+    }
+
+    @FunctionalInterface
+    interface GHCallable<O> {
+        O execute() throws IOException;
+    }
+
+    private <T> T runHandlingException(final GHCallable<T> item) throws GradleException {
+        try {
+            return item.execute();
+        } catch (final IOException ex) {
+            this.getLogger().error("Failed to execute GitHub API operation", ex);
+            throw new GradleException("GitHub API error occurred, see log for details: " + ex.getMessage());
+        }
+    }
+}

--- a/build-logic/src/main/java/org/enginehub/build/worldeditcui/ReleaseJobParameters.java
+++ b/build-logic/src/main/java/org/enginehub/build/worldeditcui/ReleaseJobParameters.java
@@ -1,0 +1,51 @@
+package org.enginehub.build.worldeditcui;
+
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
+
+public interface ReleaseJobParameters {
+    @Input
+    @Optional // if it's not present, just use the tag name
+    Property<String> getReleaseName();
+
+    @Input
+    Property<String> getReleaseBody();
+
+    @Input
+    Property<String> getRepository();
+
+    @Input
+    Property<String> getTagName();
+
+    @Optional
+    Property<String> getSourceBranch(); // if set, will create a tag with the provided name
+
+    @Input
+    Property<Boolean> getDraft();
+
+    @Input
+    Property<Boolean> getPrerelease();
+
+    @Input
+    @Optional
+    Property<String> getDiscussionCategoryName();
+
+    @Input
+    Property<Boolean> getGenerateReleaseNotes(); // todo
+
+    @Input
+    Property<LatestState> getMakeLatest(); // todo
+
+    @InputFiles
+    ConfigurableFileCollection getArtifacts();
+
+    enum LatestState {
+        TRUE,
+        FALSE,
+        LEGACY;
+    }
+
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,5 @@
+cfProjectId=402098
+
+# Gradle
 org.gradle.jvmargs=-Xmx1G
 systemProp.org.gradle.unsafe.kotlin.assignment=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,8 @@ multiconnect-api = { module = "net.earthcomputer.multiconnect:multiconnect-api",
 worldedit = { module = "com.sk89q.worldedit:worldedit-fabric-mc1.20", version = "7.2.15" }
 
 [plugins]
+curseForgeGradle = { id = "net.darkhax.curseforgegradle", version = "1.0.14" }
+javaEcosystemCapabilities = { id = "org.gradlex.java-ecosystem-capabilities", version = "1.2" }
 loom = { id = "fabric-loom", version = "1.2.7" }
 loomQuiltflower = { id = "io.github.juuxel.loom-quiltflower", version = "1.10.0" }
 versions = { id = "com.github.ben-manes.versions", version = "0.44.0" }
-javaEcosystemCapabilities = { id = "org.gradlex.java-ecosystem-capabilities", version = "1.2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 version = "1.0"
 
 [versions]
+indra = "3.1.1"
 minecraft = "1.20"
 fabricLoader = "0.14.21"
 fabricApi = "0.83.0+1.20"
@@ -17,6 +18,11 @@ fabric-api = { module = "net.fabricmc.fabric-api:fabric-api", version.ref = "fab
 modmenu = { module = "com.terraformersmc:modmenu", version.ref = "modmenu" }
 multiconnect-api = { module = "net.earthcomputer.multiconnect:multiconnect-api", version.ref = "multiconnect" }
 worldedit = { module = "com.sk89q.worldedit:worldedit-fabric-mc1.20", version = "7.2.15" }
+
+# buildtime
+
+indra-git = { module = "net.kyori:indra-git", version.ref = "indra" }
+githubApi = { module = "org.kohsuke:github-api", version = "1.314"}
 
 [plugins]
 curseForgeGradle = { id = "net.darkhax.curseforgegradle", version = "1.0.14" }


### PR DESCRIPTION
This reduces the steps required to publish a release of the mode.

Several Gradle properties are required to be set:

- `cfApiToken`: A CurseForge API token allowed to publish to the WorldEditCUI project
- `githubToken` (or `GITHUB_TOKEN` env var): A github PAT with access to publish a release on the WorldEditCUI repository

Additionally, the repo must be in a clean state for publishing to work, and checked out to a tagged release.

A simple bash script to help with writing a changelog and pushing a release (could be stored in `<checkout>/private/do-release.sh`):

```bash
#!/usr/bin/env bash

PROJECT_DIR="$(dirname "$0")/../"
echo "$PROJECT_DIR"

TMPDIR="$PROJECT_DIR/build/tmp/releaser-$RANDOM"
mkdir -p "$TMPDIR" || true

CHANGELOG_FILE="$TMPDIR/changelog.md"

nvim "$CHANGELOG_FILE" # edit changelog file

echo "Changelog contents:"
cat "$CHANGELOG_FILE"

echo -n "Is this correct? (y/n) "
read -rn 1 RESULT; [[ $RESULT = "y" ]] || exit 1
echo ""

pushd "$PROJECT_DIR" || exit 2
git push --tags origin master # Make sure we're all pushed
"./gradlew" -Pchangelog="$CHANGELOG_FILE" publishRelease
popd || exit 2

echo "Release published!"

rm -r "$TMPDIR"
```