### PR TITLE
chore: Update license to EPL v2

### DIFF
--- a/HEADER
+++ b/HEADER
@@ -1,0 +1,7 @@
+Copyright (c) 2011-2024 WorldEditCUI team and contributors
+
+This program and the accompanying materials are made
+available under the terms of the Eclipse Public License 2.0
+which is available at https://www.eclipse.org/legal/epl-2.0/
+
+SPDX-License-Identifier: EPL-2.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,87 +1,278 @@
-Eclipse Public License -v 1.0
+Eclipse Public License - v 2.0
 
-THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
 
 1. DEFINITIONS
 
 "Contribution" means:
 
-a) in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
 
-b) in the case of each subsequent Contributor:
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
 
-i) changes to the Program, and
+"Contributor" means any person or entity that Distributes the Program.
 
-ii) additions to the Program;
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
 
-where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution 'originates' from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include additions to the Program which: (i) are separate modules of software distributed in conjunction with the Program under their own license agreement, and (ii) are not derivative works of the Program.
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
 
-"Contributor" means any person or entity that distributes the Program.
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
 
-"Licensed Patents " mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
 
-"Program" means the Contributions distributed in accordance with this Agreement.
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
 
-"Recipient" means anyone who receives the Program under this Agreement, including all Contributors.
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
 
 2. GRANT OF RIGHTS
 
-a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, distribute and sublicense the Contribution of such Contributor, if any, and such derivative works, in source code and object code form.
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
 
-b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in source code and object code form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
 
-c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to distribute the Program, it is Recipient's responsibility to acquire that license before distributing the Program.
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
 
-d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
 
 3. REQUIREMENTS
 
-A Contributor may choose to distribute the Program in object code form under its own license agreement, provided that:
+3.1 If a Contributor Distributes the Program in any form, then:
 
-a) it complies with the terms and conditions of this Agreement; and
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
 
-b) its license agreement:
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
 
-i) effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
 
-ii) effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
 
-iii) states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
 
-iv) states that source code for the Program is available from such Contributor, and informs licensees how to obtain it in a reasonable manner on or through a medium customarily used for software exchange.
+3.2 When the Program is Distributed as Source Code:
 
-When the Program is made available in source code form:
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
 
-a) it must be made available under this Agreement; and
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
 
-b) a copy of this Agreement must be included with each copy of the Program.
-
-Contributors may not remove or alter any copyright notices contained within the Program.
-
-Each Contributor must identify itself as the originator of its Contribution, if any, in a manner that reasonably allows subsequent Recipients to identify the originator of the Contribution.
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
 
 4. COMMERCIAL DISTRIBUTION
 
-Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor ("Commercial Contributor") hereby agrees to defend and indemnify every other Contributor ("Indemnified Contributor") against any losses, damages and costs (collectively "Losses") arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
 
-For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor's responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
 
 5. NO WARRANTY
 
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement , including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
 
 6. DISCLAIMER OF LIABILITY
 
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
 
 7. GENERAL
 
-If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
 
-If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient's patent(s), then such Recipient's rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
 
-All Recipient's rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient's rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient's obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
 
-Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to distribute the Program (including its Contributions) under the new version. Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved.
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
 
-This Agreement is governed by the laws of the State of New York and the intellectual property laws of the United States of America. No party to this Agreement will bring a legal action under this Agreement more than one year after the cause of action arose. Each party waives its rights to a jury trial in any resulting litigation.
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set forth
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.
+

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Credits
 Legal stuff
 -----------
 
-The code for WorldEditCUI (and therefore the compiled mod) is licensed under the [Eclipse Public License v1].
+The code for WorldEditCUI (and therefore the compiled mod) is licensed under the [Eclipse Public License v2].
 
 [WorldEdit]: https://enginehub.org/worldedit/
-[Eclipse Public License v1]: https://www.eclipse.org/org/documents/epl-v10.php
+[Eclipse Public License v2]: https://www.eclipse.org/legal/epl-2.0/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,12 +5,14 @@ import net.fabricmc.loom.LoomGradleExtension
 plugins {
     java
     alias(libs.plugins.indra.git)
+    alias(libs.plugins.indra.spotlessLicenser)
     alias(libs.plugins.loom)
     alias(libs.plugins.versions)
     alias(libs.plugins.javaEcosystemCapabilities)
     alias(libs.plugins.curseForgeGradle)
     alias(libs.plugins.minotaur)
     alias(libs.plugins.publishGithubRelease)
+    alias(libs.plugins.spotless)
 }
 
 group = "org.enginehub.worldeditcui"
@@ -46,6 +48,10 @@ tasks.withType(JavaCompile::class).configureEach {
     options.release = targetVersion
     options.encoding = "UTF-8"
     options.compilerArgs.addAll(listOf("-Xlint:all", "-Xlint:-processing"))
+}
+
+indraSpotlessLicenser {
+    licenseHeaderFile(rootProject.file("HEADER"))
 }
 
 loom {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,8 +25,10 @@ worldedit = { module = "com.sk89q.worldedit:worldedit-fabric-mc1.20.2", version 
 [plugins]
 curseForgeGradle = { id = "net.darkhax.curseforgegradle", version = "1.1.17" }
 indra-git = { id = "net.kyori.indra.git", version.ref = "indra" }
+indra-spotlessLicenser = { id = "net.kyori.indra.licenser.spotless", version.ref = "indra" }
 javaEcosystemCapabilities = { id = "org.gradlex.java-ecosystem-capabilities", version = "1.3.1" }
 loom = { id = "fabric-loom", version = "1.4.4" }
 minotaur = { id = "com.modrinth.minotaur", version = "2.8.7" }
 publishGithubRelease = { id = "ca.stellardrift.publish-github-release", version = "0.1.0" }
+spotless = { id = "com.diffplug.spotless", version = "6.25.0" }
 versions = { id = "com.github.ben-manes.versions", version = "0.50.0" }

--- a/src/main/java/org/enginehub/worldeditcui/InitialisationFactory.java
+++ b/src/main/java/org/enginehub/worldeditcui/InitialisationFactory.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui;
 
 import org.enginehub.worldeditcui.exceptions.InitialisationException;

--- a/src/main/java/org/enginehub/worldeditcui/WorldEditCUI.java
+++ b/src/main/java/org/enginehub/worldeditcui/WorldEditCUI.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui;
 
 import net.minecraft.client.Minecraft;

--- a/src/main/java/org/enginehub/worldeditcui/config/CUIConfiguration.java
+++ b/src/main/java/org/enginehub/worldeditcui/config/CUIConfiguration.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.config;
 
 import com.google.gson.Gson;

--- a/src/main/java/org/enginehub/worldeditcui/config/Colour.java
+++ b/src/main/java/org/enginehub/worldeditcui/config/Colour.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.config;
 
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/org/enginehub/worldeditcui/debug/CUIDebug.java
+++ b/src/main/java/org/enginehub/worldeditcui/debug/CUIDebug.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.debug;
 
 import net.fabricmc.loader.api.FabricLoader;

--- a/src/main/java/org/enginehub/worldeditcui/debug/DebugModeEnabledFilter.java
+++ b/src/main/java/org/enginehub/worldeditcui/debug/DebugModeEnabledFilter.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.debug;
 
 import org.apache.logging.log4j.Level;

--- a/src/main/java/org/enginehub/worldeditcui/event/CUIEvent.java
+++ b/src/main/java/org/enginehub/worldeditcui/event/CUIEvent.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.event;
 
 import com.google.common.base.Joiner;

--- a/src/main/java/org/enginehub/worldeditcui/event/CUIEventArgs.java
+++ b/src/main/java/org/enginehub/worldeditcui/event/CUIEventArgs.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.event;
 
 import com.google.common.base.Joiner;

--- a/src/main/java/org/enginehub/worldeditcui/event/CUIEventDispatcher.java
+++ b/src/main/java/org/enginehub/worldeditcui/event/CUIEventDispatcher.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.event;
 
 import org.enginehub.worldeditcui.InitialisationFactory;

--- a/src/main/java/org/enginehub/worldeditcui/event/CUIEventType.java
+++ b/src/main/java/org/enginehub/worldeditcui/event/CUIEventType.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.event;
 
 import org.enginehub.worldeditcui.event.cui.CUIEventBounds;

--- a/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventBounds.java
+++ b/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventBounds.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.event.cui;
 
 import org.enginehub.worldeditcui.event.CUIEvent;

--- a/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventColour.java
+++ b/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventColour.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.event.cui;
 
 import org.enginehub.worldeditcui.config.Colour;

--- a/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventCylinder.java
+++ b/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventCylinder.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.event.cui;
 
 import org.enginehub.worldeditcui.event.CUIEvent;

--- a/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventEllipsoid.java
+++ b/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventEllipsoid.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.event.cui;
 
 import org.enginehub.worldeditcui.event.CUIEvent;

--- a/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventGrid.java
+++ b/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventGrid.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.event.cui;
 
 import org.enginehub.worldeditcui.event.CUIEvent;

--- a/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventPoint2D.java
+++ b/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventPoint2D.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.event.cui;
 
 import org.enginehub.worldeditcui.event.CUIEventArgs;

--- a/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventPoint3D.java
+++ b/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventPoint3D.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.event.cui;
 
 import net.minecraft.client.Minecraft;

--- a/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventPolygon.java
+++ b/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventPolygon.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.event.cui;
 
 import org.enginehub.worldeditcui.event.CUIEvent;

--- a/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventSelection.java
+++ b/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventSelection.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.event.cui;
 
 import org.enginehub.worldeditcui.event.CUIEvent;

--- a/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventUpdate.java
+++ b/src/main/java/org/enginehub/worldeditcui/event/cui/CUIEventUpdate.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.event.cui;
 
 import org.enginehub.worldeditcui.event.CUIEvent;

--- a/src/main/java/org/enginehub/worldeditcui/event/listeners/CUIListenerChannel.java
+++ b/src/main/java/org/enginehub/worldeditcui/event/listeners/CUIListenerChannel.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.event.listeners;
 
 import org.enginehub.worldeditcui.WorldEditCUI;

--- a/src/main/java/org/enginehub/worldeditcui/event/listeners/CUIListenerWorldRender.java
+++ b/src/main/java/org/enginehub/worldeditcui/event/listeners/CUIListenerWorldRender.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.event.listeners;
 
 import com.mojang.blaze3d.platform.GlStateManager;

--- a/src/main/java/org/enginehub/worldeditcui/event/listeners/CUIRenderContext.java
+++ b/src/main/java/org/enginehub/worldeditcui/event/listeners/CUIRenderContext.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.event.listeners;
 
 import com.mojang.blaze3d.systems.RenderSystem;

--- a/src/main/java/org/enginehub/worldeditcui/exceptions/InitialisationException.java
+++ b/src/main/java/org/enginehub/worldeditcui/exceptions/InitialisationException.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.exceptions;
 
 /**

--- a/src/main/java/org/enginehub/worldeditcui/exceptions/InvalidSelectionTypeException.java
+++ b/src/main/java/org/enginehub/worldeditcui/exceptions/InvalidSelectionTypeException.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.exceptions;
 
 public class InvalidSelectionTypeException extends RuntimeException

--- a/src/main/java/org/enginehub/worldeditcui/fabric/CUINetworking.java
+++ b/src/main/java/org/enginehub/worldeditcui/fabric/CUINetworking.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.fabric;
 
 import net.earthcomputer.multiconnect.api.MultiConnectAPI;

--- a/src/main/java/org/enginehub/worldeditcui/fabric/ConfigPanelFactory.java
+++ b/src/main/java/org/enginehub/worldeditcui/fabric/ConfigPanelFactory.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.fabric;
 
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;

--- a/src/main/java/org/enginehub/worldeditcui/fabric/FabricModWorldEditCUI.java
+++ b/src/main/java/org/enginehub/worldeditcui/fabric/FabricModWorldEditCUI.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.fabric;
 
 import com.mojang.blaze3d.platform.InputConstants;

--- a/src/main/java/org/enginehub/worldeditcui/fabric/ViaFabricPlusHook.java
+++ b/src/main/java/org/enginehub/worldeditcui/fabric/ViaFabricPlusHook.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.fabric;
 
 import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.Protocol1_13To1_12_2;

--- a/src/main/java/org/enginehub/worldeditcui/fabric/mixins/MinecraftAccess.java
+++ b/src/main/java/org/enginehub/worldeditcui/fabric/mixins/MinecraftAccess.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.fabric.mixins;
 
 import net.minecraft.client.Minecraft;

--- a/src/main/java/org/enginehub/worldeditcui/gui/CUIConfigList.java
+++ b/src/main/java/org/enginehub/worldeditcui/gui/CUIConfigList.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.gui;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/enginehub/worldeditcui/gui/CUIConfigPanel.java
+++ b/src/main/java/org/enginehub/worldeditcui/gui/CUIConfigPanel.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.gui;
 
 import net.minecraft.client.gui.GuiGraphics;

--- a/src/main/java/org/enginehub/worldeditcui/render/BufferBuilderRenderSink.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/BufferBuilderRenderSink.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render;
 
 import com.mojang.blaze3d.systems.RenderSystem;

--- a/src/main/java/org/enginehub/worldeditcui/render/CUISelectionProvider.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/CUISelectionProvider.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render;
 
 import org.enginehub.worldeditcui.InitialisationFactory;

--- a/src/main/java/org/enginehub/worldeditcui/render/ConfiguredColour.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/ConfiguredColour.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render;
 
 import net.minecraft.client.resources.language.I18n;

--- a/src/main/java/org/enginehub/worldeditcui/render/CustomStyle.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/CustomStyle.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render;
 
 import org.enginehub.worldeditcui.config.Colour;

--- a/src/main/java/org/enginehub/worldeditcui/render/LineStyle.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/LineStyle.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render;
 
 import org.enginehub.worldeditcui.render.RenderStyle.RenderType;

--- a/src/main/java/org/enginehub/worldeditcui/render/OptifinePipelineProvider.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/OptifinePipelineProvider.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render;
 
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;

--- a/src/main/java/org/enginehub/worldeditcui/render/PipelineProvider.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/PipelineProvider.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render;
 
 /**

--- a/src/main/java/org/enginehub/worldeditcui/render/RenderSink.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/RenderSink.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render;
 
 import org.enginehub.worldeditcui.config.Colour;

--- a/src/main/java/org/enginehub/worldeditcui/render/RenderStyle.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/RenderStyle.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render;
 
 import org.enginehub.worldeditcui.config.Colour;

--- a/src/main/java/org/enginehub/worldeditcui/render/VanillaPipelineProvider.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/VanillaPipelineProvider.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render;
 
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;

--- a/src/main/java/org/enginehub/worldeditcui/render/points/PointCube.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/points/PointCube.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.points;
 
 import org.enginehub.worldeditcui.event.listeners.CUIRenderContext;

--- a/src/main/java/org/enginehub/worldeditcui/render/points/PointCubeTracking.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/points/PointCubeTracking.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.points;
 
 import net.minecraft.core.BlockPos;

--- a/src/main/java/org/enginehub/worldeditcui/render/points/PointRectangle.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/points/PointRectangle.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.points;
 
 import org.enginehub.worldeditcui.event.listeners.CUIRenderContext;

--- a/src/main/java/org/enginehub/worldeditcui/render/region/CuboidRegion.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/region/CuboidRegion.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.region;
 
 import net.minecraft.world.entity.Entity;

--- a/src/main/java/org/enginehub/worldeditcui/render/region/CylinderRegion.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/region/CylinderRegion.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.region;
 
 import org.enginehub.worldeditcui.WorldEditCUI;

--- a/src/main/java/org/enginehub/worldeditcui/render/region/EllipsoidRegion.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/region/EllipsoidRegion.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.region;
 
 import org.enginehub.worldeditcui.WorldEditCUI;

--- a/src/main/java/org/enginehub/worldeditcui/render/region/PolygonRegion.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/region/PolygonRegion.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.region;
 
 import org.enginehub.worldeditcui.WorldEditCUI;

--- a/src/main/java/org/enginehub/worldeditcui/render/region/PolyhedronRegion.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/region/PolyhedronRegion.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.region;
 
 import org.enginehub.worldeditcui.WorldEditCUI;

--- a/src/main/java/org/enginehub/worldeditcui/render/region/Region.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/region/Region.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.region;
 
 import net.minecraft.world.entity.Entity;

--- a/src/main/java/org/enginehub/worldeditcui/render/region/RegionType.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/region/RegionType.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.region;
 
 import org.enginehub.worldeditcui.WorldEditCUI;

--- a/src/main/java/org/enginehub/worldeditcui/render/shapes/Render2DBox.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/shapes/Render2DBox.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.shapes;
 
 import org.enginehub.worldeditcui.event.listeners.CUIRenderContext;

--- a/src/main/java/org/enginehub/worldeditcui/render/shapes/Render2DGrid.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/shapes/Render2DGrid.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.shapes;
 
 import org.enginehub.worldeditcui.event.listeners.CUIRenderContext;

--- a/src/main/java/org/enginehub/worldeditcui/render/shapes/Render3DBox.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/shapes/Render3DBox.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.shapes;
 
 import org.enginehub.worldeditcui.event.listeners.CUIRenderContext;

--- a/src/main/java/org/enginehub/worldeditcui/render/shapes/Render3DGrid.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/shapes/Render3DGrid.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.shapes;
 
 import com.mojang.blaze3d.systems.RenderSystem;

--- a/src/main/java/org/enginehub/worldeditcui/render/shapes/Render3DPolygon.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/shapes/Render3DPolygon.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.shapes;
 
 import org.enginehub.worldeditcui.event.listeners.CUIRenderContext;

--- a/src/main/java/org/enginehub/worldeditcui/render/shapes/RenderChunkBoundary.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/shapes/RenderChunkBoundary.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.shapes;
 
 import net.minecraft.client.Minecraft;

--- a/src/main/java/org/enginehub/worldeditcui/render/shapes/RenderCylinderBox.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/shapes/RenderCylinderBox.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.shapes;
 
 import org.enginehub.worldeditcui.event.listeners.CUIRenderContext;

--- a/src/main/java/org/enginehub/worldeditcui/render/shapes/RenderCylinderCircles.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/shapes/RenderCylinderCircles.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.shapes;
 
 import org.enginehub.worldeditcui.event.listeners.CUIRenderContext;

--- a/src/main/java/org/enginehub/worldeditcui/render/shapes/RenderCylinderGrid.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/shapes/RenderCylinderGrid.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.shapes;
 
 import org.enginehub.worldeditcui.event.listeners.CUIRenderContext;

--- a/src/main/java/org/enginehub/worldeditcui/render/shapes/RenderEllipsoid.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/shapes/RenderEllipsoid.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.shapes;
 
 import org.enginehub.worldeditcui.event.listeners.CUIRenderContext;

--- a/src/main/java/org/enginehub/worldeditcui/render/shapes/RenderRegion.java
+++ b/src/main/java/org/enginehub/worldeditcui/render/shapes/RenderRegion.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.render.shapes;
 
 import org.enginehub.worldeditcui.event.listeners.CUIRenderContext;

--- a/src/main/java/org/enginehub/worldeditcui/util/BoundingBox.java
+++ b/src/main/java/org/enginehub/worldeditcui/util/BoundingBox.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.util;
 
 import org.enginehub.worldeditcui.render.points.PointCube;

--- a/src/main/java/org/enginehub/worldeditcui/util/Observable.java
+++ b/src/main/java/org/enginehub/worldeditcui/util/Observable.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.util;
 
 import java.util.ArrayList;

--- a/src/main/java/org/enginehub/worldeditcui/util/Observer.java
+++ b/src/main/java/org/enginehub/worldeditcui/util/Observer.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.util;
 
 /**

--- a/src/main/java/org/enginehub/worldeditcui/util/Vector2.java
+++ b/src/main/java/org/enginehub/worldeditcui/util/Vector2.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.util;
 
 /**

--- a/src/main/java/org/enginehub/worldeditcui/util/Vector2m.java
+++ b/src/main/java/org/enginehub/worldeditcui/util/Vector2m.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.util;
 
 /**

--- a/src/main/java/org/enginehub/worldeditcui/util/Vector3.java
+++ b/src/main/java/org/enginehub/worldeditcui/util/Vector3.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2011-2024 WorldEditCUI team and contributors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.enginehub.worldeditcui.util;
 
 import net.minecraft.world.entity.Entity;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "sources": "https://github.com/EngineHub/WorldEditCUI"
   },
   "icon": "assets/worldeditcui/icon.png",
-  "license": "EPL-1.0",
+  "license": "EPL-2.0",
   "environment": "client",
   "entrypoints": {
     "main": [


### PR DESCRIPTION
The current license contributions have been provided under, EPL v1, grants permission to use a newer version of the same license, so this can be applicable immediately.

This version has [several improvements](https://www.eclipse.org/legal/epl-2.0/faq.php#h.a0eux401qus), most importantly removing the choice of law provisions that mention a jurisdiction foreign to many contributors.