### PR TITLE
Include worldeditcui-protocol-common in fabric build

### DIFF
--- a/worldeditcui-fabric/build.gradle.kts
+++ b/worldeditcui-fabric/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation(project(":worldeditcui-protocol-fabric", configuration = "namedElements")) { isTransitive = false }
     implementation(project(":worldeditcui-protocol-common", configuration = "namedElements")) { isTransitive = false }
     include(project(":worldeditcui-protocol-fabric"))
+    include(project(":worldeditcui-protocol-common"))
     modImplementation(libs.fabric.loader)
     modImplementation(libs.modmenu)
     modCompileOnly(libs.viafabricplus.api) {


### PR DESCRIPTION
The library worldeditcui-protocol-common seems to have to be included for the fabric build.

Without this I got errors that CUIPacket not being defined while loading the mod.